### PR TITLE
Only print out messages that we care about

### DIFF
--- a/src/FOMObot/App.hs
+++ b/src/FOMObot/App.hs
@@ -1,5 +1,6 @@
 module FOMObot.App
     ( runApp
+    , messageProcessor
     ) where
 
 import System.Environment (getEnv)
@@ -12,6 +13,18 @@ import qualified Data.Text as T
 import FOMObot.RTM (rtmStartResponse)
 import FOMObot.Websockets (runSecureClient)
 import FOMObot.Types.RTMStartResponse
+import FOMObot.Types.Message
+import FOMObot.Types.MessageProcessor
+
+messageProcessor :: MessageProcessor
+messageProcessor = either doNothing printMessage
+    where
+        doNothing = const $ return ()
+
+printMessage :: Message -> IO ()
+printMessage m@(Message t _ _ _)
+    | t == "message" = print m
+    | otherwise = return ()
 
 runApp :: IO ()
 runApp = do
@@ -19,4 +32,4 @@ runApp = do
     response <- rtmStartResponse token
     let socketURL = _url $ response ^. responseBody
     let uri = fromJust $ parseURI socketURL
-    runSecureClient uri
+    runSecureClient uri messageProcessor

--- a/src/FOMObot/Types/Message.hs
+++ b/src/FOMObot/Types/Message.hs
@@ -7,6 +7,7 @@ data Message = Message
     { _type :: String
     , _channel :: String
     , _ts :: String
+    , _text :: String
     } deriving (Show)
 
 instance FromJSON Message where
@@ -14,5 +15,6 @@ instance FromJSON Message where
         <$> o .: "type"
         <*> o .: "channel"
         <*> o .: "ts"
+        <*> o .: "text"
 
     parseJSON invalid = typeMismatch "Message" invalid

--- a/src/FOMObot/Types/MessageProcessor.hs
+++ b/src/FOMObot/Types/MessageProcessor.hs
@@ -1,0 +1,5 @@
+module FOMObot.Types.MessageProcessor where
+
+import FOMObot.Types.Message
+
+type MessageProcessor = Either String Message -> IO ()

--- a/src/FOMObot/Websockets.hs
+++ b/src/FOMObot/Websockets.hs
@@ -10,21 +10,20 @@ import qualified Wuss
 import qualified Network.WebSockets as WS
 import qualified Data.Text as T
 
-import FOMObot.Types.Message
+import FOMObot.Types.MessageProcessor
 
-app :: WS.ClientApp ()
-app connection = do
+app :: MessageProcessor -> WS.ClientApp ()
+app processor connection = do
     putStrLn "Connected!"
 
     void . forever $ do
         message <- WS.receiveData connection
-        let msg = eitherDecode message :: Either String Message
-        print msg
+        processor $ eitherDecode message
 
     WS.sendClose connection $ T.pack "Bye!"
 
-runSecureClient :: URI -> IO ()
-runSecureClient uri = Wuss.runSecureClient host 443 path app
+runSecureClient :: URI -> MessageProcessor -> IO ()
+runSecureClient uri processor = Wuss.runSecureClient host 443 path $ app processor
     where
         host = fromJust $ uriRegName <$> uriAuthority uri
         path = uriPath uri


### PR DESCRIPTION
We accomplish this by creating a `MessageProcessor` type that takes in a `Either String Message` and decides what to do with it.

We inject the `messageProcessor` from `App.hs` into our websocket client, which in turn calls `messageProcessor` when it receives JSON over the websocket.
