### PR TITLE
Change buffering modes of stdout and stderr

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,4 +1,8 @@
+import System.IO (hSetBuffering, stdout, stderr, BufferMode(..))
+
 import FOMObot.App (runApp)
 
 main :: IO ()
-main = runApp
+main = do
+    hSetBuffering stdout LineBuffering
+    runApp


### PR DESCRIPTION
When deployed to Heroku, stdout isn't appearing. This is a common issue
where apps need to disable stdout buffering. We should also do this with
stderr to make sure those print to the Heroku logs as well.

https://github.com/commercialhaskell/stack/pull/360/files
