### PR TITLE
Clarify record use where appropriate

### DIFF
--- a/fomobot.cabal
+++ b/fomobot.cabal
@@ -23,6 +23,7 @@ executable fomobot
                      , DeriveGeneric
                      , DeriveAnyClass
                      , RecordWildCards
+                     , NamedFieldPuns
 
   build-depends:       base >=4.8 && <4.9
                      , wreq

--- a/src/FOMObot/App.hs
+++ b/src/FOMObot/App.hs
@@ -20,7 +20,7 @@ import FOMObot.Types.BotConfig
 
 runApp :: Bot ()
 runApp = do
-    message@Message{..} <- receiveMessage
+    message@Message{messageText} <- receiveMessage
     printBot message
     alertFOMOChannel messageText
     state <- get

--- a/src/FOMObot/Helpers/Bot.hs
+++ b/src/FOMObot/Helpers/Bot.hs
@@ -24,9 +24,10 @@ receiveMessage = untilJust $ maybeFilter =<< decode <$> receiveData
         maybeFilter = maybe (return Nothing) filterMessage
 
 filterMessage :: Message -> Bot (Maybe Message)
-filterMessage m@Message{..} = ask >>= return . botMessageFilter
+filterMessage m@Message{messageType, messageChannelID, messageUserID} =
+    ask >>= return . botMessageFilter
     where
-        botMessageFilter BotConfig{..}
+        botMessageFilter BotConfig{configChannelID, configBotID}
             | messageType == "message" && messageChannelID /= configChannelID && messageUserID /= configBotID = Just m
             | otherwise = Nothing
 


### PR DESCRIPTION
Use NamedFieldPuns style record syntax in place of RecordWildCards in
places that don't use all the properties and where it's usage helps to
clarify where the properties are coming from.
