### PR TITLE
Add required dependencies for Slack API 0.12 upgrade

### DIFF
--- a/docker/Web.plan
+++ b/docker/Web.plan
@@ -8,6 +8,7 @@ WORKDIR /app
 
 RUN apt-get update \
   && apt-get install -y \
+    netbase \
     ca-certificates \
     libgmp10 \
     libpq5 \

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,6 +12,7 @@ extra-deps:
   - hedis-0.8.3
   - scanner-0.2
   - tagged-0.8.5
+  - transformers-compat-0.5.1.4
 
 # Extra directories used by stack for building
 extra-include-dirs: [/usr/local/opt/openssl/include]

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,6 +9,8 @@ packages:
 
 extra-deps:
   - slack-api-0.12
+  - wuss-1.1.6
+  - aeson-0.11.3.0
   - hedis-0.8.3
   - scanner-0.2
   - tagged-0.8.5

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,6 +11,7 @@ extra-deps:
   - slack-api-0.12
   - hedis-0.8.3
   - scanner-0.2
+  - tagged-0.8.5
 
 # Extra directories used by stack for building
 extra-include-dirs: [/usr/local/opt/openssl/include]


### PR DESCRIPTION
Based on #29, which is approved but not merged. This is working for Poll Everywhere in Heroku.

Cherry-picks @patcon's commits from the [CivicTechTO fork](https://github.com/CivicTechTO/FOMObot/tree/fix-build-for-heroku).